### PR TITLE
Avoid crashing

### DIFF
--- a/android/src/main/java/com/goldenowl/twittersignin/TwitterSigninModule.java
+++ b/android/src/main/java/com/goldenowl/twittersignin/TwitterSigninModule.java
@@ -80,7 +80,7 @@ public class TwitterSigninModule extends ReactContextBaseJavaModule implements A
             @Override
             public void failure(TwitterException exception) {
                 Log.d("failure", exception.toString());
-                callback.invoke(exception, null);
+                callback.invoke(exception.toString(), null);
             }
         });
     }


### PR DESCRIPTION
Avoid android app from crashing when the user hits back button. apparently callback.invoke doesn't like exceptions, maybe not the best solution but avoids crashing.
