### PR TITLE
Modified .podspec and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,29 @@ Firstly, install the npm package:
 
     npm install react-native-twitter-signin --save
 
+or
+
+    yarn add react-native-twitter-signin
+
 #### iOS
+
+##### CocoaPods
+
+ - Running `react-native link react-native-twitter-link`
+ - Go into `ios` folder and run `pod install`
+
+##### Manual
 
  - Link RNTwitterSignIn.xcodeproj by running `react-native link react-native-twitter-signin`
  - Download TwitterKit 3.0 from here https://ton.twimg.com/syndication/twitterkit/ios/3.0.3-update/TwitterKitManual.zip
  - Add TwitterKit, TwitterCore and 2 other bundle files into your root folder in Xcode
  - In `Build Phases → Link Binary with libraries` add `Twitter.framework` and `LibRBTwitterSignin.a`
- - Configure Info.Plist like below, replace `<consumerKey>` with your own key:
+
+---
+
+After done all the steps in `CocoaPods` or `Manual`, please do the following steps:
+
+ - Configure `Info.plist` like below, replace `<consumerKey>` with your own key:
 
 ```
 // Info.plist
@@ -53,13 +69,33 @@ Firstly, install the npm package:
     <string>twitterauth</string>
 </array>
 ```
-  - Modify AppDelegate.m to `#import <TwitterKit/TwitterKit.h>` and handle openUrl
+  - Modify AppDelegate.m to `#import <TwitterKit/TwitterKit.h>` and handle `openUrl`
 ````
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options {
   return [[Twitter sharedInstance] application:app openURL:url options:options];
 }
 ````
-  
+
+*Notice:* Only one `openURL` method can be defined, so if you already defined other login method (like Google or Facebook) before,
+you must combine the functions into single one:
+
+```
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+
+  BOOL handleFB = [[FBSDKApplicationDelegate sharedInstance] application:application
+    openURL:url
+    sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
+    annotation:options[UIApplicationOpenURLOptionsAnnotationKey]
+  ];
+
+  BOOL handleTwitter = [[Twitter sharedInstance] application:application openURL:url options:options];
+
+  return handleFB || handleTwitter;
+}
+```
+
 
 #### Android
 

--- a/react-native-twitter-signin.podspec
+++ b/react-native-twitter-signin.podspec
@@ -15,5 +15,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency "React"
-  s.dependency "TwitterKit"
+  s.dependency "TwitterKit", "3.2.2"
+  s.dependency "TwitterCore", "3.0.3"
 end

--- a/react-native-twitter-signin.podspec
+++ b/react-native-twitter-signin.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage    = package['homepage']
   s.license     = package['license']
   s.author      = 'Justin Nguyen'
-  s.platform    = :ios, "8.0"
+  s.platform    = :ios, "9.0"
   s.source      = { :git => "https://github.com/GoldenOwlAsia/react-native-twitter-signin.git", :tag => "#{s.version}" }
 
   s.source_files  = "ios/*.{h,m}"


### PR DESCRIPTION
* Modified podspec to specific TwitterKit & TwitterCore version, and fix the iOS platform version (9.0)
* Update README

I made this fix because I encounter a build fail issue when build with TwitterKit 3.3.0 (the latest version in current time):

```
▸ Compiling RNTwitterSignIn.m

❌  /Users/patw/Projects/cryp/node_modules/react-native-twitter-signin/ios/RNTwitterSignIn.m:9:9: 'TwitterKit/TwitterKit.h' file not found

#import <TwitterKit/TwitterKit.h>
                                                                                     ^

** BUILD FAILED **
```

It seems that we should use lower TwitterKit version (and the TwitterCore dependency) to avoid this.

---

Another important thing, this package's 1.0.2 version is not include the podspec file. So if you want to install with cocoapods, please install with the github's master branch in current time.
