### PR TITLE
Remove createJsModule override

### DIFF
--- a/android/src/main/java/com/goldenowl/twittersignin/TwitterSigninPackage.java
+++ b/android/src/main/java/com/goldenowl/twittersignin/TwitterSigninPackage.java
@@ -28,11 +28,6 @@ public class TwitterSigninPackage implements ReactPackage {
         return modules;
     }
 
-    // Deprecated RN 0.47
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList();
     }


### PR DESCRIPTION
https://github.com/facebook/react-native/releases/tag/v0.47.0
React Native 0.47 removed createJSModules on Android