### PR TITLE
fix multiple callback crash after login

### DIFF
--- a/ios/RNTwitterSignIn.m
+++ b/ios/RNTwitterSignIn.m
@@ -18,6 +18,8 @@
     return dispatch_get_main_queue();
 }
 
+BOOL authNotResolved = true;
+
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(init: (NSString *)consumerKey consumerSecret:(NSString *)consumerSecret resolver:(RCTPromiseResolveBlock)resolve
@@ -39,7 +41,10 @@ RCT_EXPORT_METHOD(logIn: (RCTPromiseResolveBlock)resolve
                                        @"userID":session.userID,
                                        @"email": requestedEmail,
                                        @"userName":session.userName};
-                resolve(body);
+                if(authNotResolved){
+                    resolve(body);
+                    authNotResolved = false;
+                }
             }];
         } else {
             reject(@"Error", @"Twitter signin error", error);


### PR DESCRIPTION
issue #141 

For some reason, `resolve()` is getting called twice that's the reason it was getting crashed with 

`illegal callback invocation from native module. this callback type only permits a single invocation from native code.`

So added a boolean check to stop calling multiple times.

And it worked.